### PR TITLE
Remove gemspec from Gemfile to fix GitHub Pages build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
-gemspec
 
 gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]
 gem "kramdown-parser-gfm" if ENV["JEKYLL_VERSION"] == "~> 3.9"


### PR DESCRIPTION
The gemspec directive referenced a non-existent .gemspec file,
which would cause the build to fail.

https://claude.ai/code/session_01HE9HRDS8jvxN5THW94ebu3