### PR TITLE
Add jekyll-scholar to plugins list to fix build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+_site/
+.jekyll-cache/
+.jekyll-metadata
+.sass-cache/
+vendor/
+node_modules/

--- a/_config.yml
+++ b/_config.yml
@@ -150,6 +150,7 @@ plugins:
   - jekyll-minifier
   - jekyll-paginate-v2
   - jekyll-regex-replace
+  - jekyll-scholar
   - jekyll-sitemap
   - jekyll-socials
   - jekyll-tabs


### PR DESCRIPTION
The bibliography tag in _layouts/post.liquid requires jekyll-scholar
to be listed in _config.yml plugins, not just in the Gemfile.

https://claude.ai/code/session_01YJfHWp7QGq4FcusiuGEWPD