### PR TITLE
Add Python/Jupyter setup to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,12 @@ jobs:
         with:
           ruby-version: "3.3.5"
           bundler-cache: true
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install Python dependencies
+        run: pip install jupyter nbconvert
       - name: Install and Build
         run: |
           sudo apt-get update && sudo apt-get install -y imagemagick


### PR DESCRIPTION
The jekyll-jupyter-notebook plugin requires the jupyter command to convert .ipynb files during build. Install Python and nbconvert in the CI environment.

https://claude.ai/code/session_01YJfHWp7QGq4FcusiuGEWPD