### PR TITLE
Set dark mode as the default theme

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -270,7 +270,7 @@ let transTheme = () => {
 let determineThemeSetting = () => {
   let themeSetting = localStorage.getItem("theme");
   if (themeSetting != "dark" && themeSetting != "light" && themeSetting != "system") {
-    themeSetting = "system";
+    themeSetting = "dark";
   }
   return themeSetting;
 };


### PR DESCRIPTION
New visitors will see dark mode by default instead of following system preference. Users can still toggle between light/dark/system.

https://claude.ai/code/session_01YJfHWp7QGq4FcusiuGEWPD