### PR TITLE
Add Projects page with Risk Regime Dashboard

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,6 +20,7 @@
           <li><a href="{{ '/' | relative_url }}">Home</a></li>
           <li><a href="{{ '/blog' | relative_url }}">Blog</a></li>
           <li><a href="{{ '/about' | relative_url }}">About</a></li>
+          <li><a href="{{ '/projects' | relative_url }}">Projects</a></li>
           <li><a href="{{ '/cv' | relative_url }}">CV</a></li>
           <li><a href="{{ '/research' | relative_url }}">Research</a></li>
         </ul>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -464,6 +464,69 @@ img {
   }
 }
 
+/* === Projects === */
+.projects-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+}
+
+.project-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 2rem;
+}
+
+.project-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.75rem;
+}
+
+.project-desc {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  line-height: 1.7;
+  margin-bottom: 1rem;
+}
+
+.project-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.project-embed {
+  margin-bottom: 1.25rem;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+.project-embed iframe {
+  width: 100%;
+  height: 500px;
+  border: none;
+  background: var(--bg-secondary);
+}
+
+.project-link {
+  display: inline-flex;
+}
+
+@media (max-width: 640px) {
+  .project-card {
+    padding: 1.25rem;
+  }
+
+  .project-embed iframe {
+    height: 350px;
+  }
+}
+
 /* === Post Page === */
 .post-header {
   padding: 8rem 0 1rem;

--- a/projects.md
+++ b/projects.md
@@ -1,0 +1,26 @@
+---
+layout: page
+title: Projects
+permalink: /projects/
+---
+
+<div class="projects-grid">
+
+  <div class="project-card">
+    <h3 class="project-title">Risk Regime Dashboard</h3>
+    <p class="project-desc">A live macro and risk regime dashboard that classifies the U.S. economy as expansion/contraction and market conditions as risk-on/mixed/risk-off using FRED data. Tracks 12 economic indicators including industrial production, yield curve, S&amp;P 500 trend, credit spreads, and VIX. Auto-updated monthly via GitHub Actions.</p>
+    <div class="project-tags">
+      <span class="cv-tag">Python</span>
+      <span class="cv-tag">FRED API</span>
+      <span class="cv-tag">GitHub Actions</span>
+      <span class="cv-tag">Plotly</span>
+    </div>
+    <div class="project-embed">
+      <iframe src="https://danahagist.github.io/risk-regime-data/" title="Risk Regime Dashboard" loading="lazy"></iframe>
+    </div>
+    <a href="https://danahagist.github.io/risk-regime-data/" target="_blank" class="btn project-link">View full dashboard &rarr;</a>
+  </div>
+
+</div>
+
+<!-- To add more projects, copy a project-card block above and fill in your details -->


### PR DESCRIPTION
New projects page with card grid layout, embedded live dashboard iframe, and tech stack tags. Added Projects link to navigation. Easy to extend by copying the project-card block.

https://claude.ai/code/session_01YJfHWp7QGq4FcusiuGEWPD