### PR TITLE
Remove nav logo to reduce mobile nav crowding

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,6 @@
   <div class="site-wrapper">
     <nav class="site-nav">
       <div class="nav-inner">
-        <a href="{{ '/' | relative_url }}" class="nav-logo">{{ site.author }}</a>
         <ul class="nav-links">
           <li><a href="{{ '/' | relative_url }}">Home</a></li>
           <li><a href="{{ '/blog' | relative_url }}">Blog</a></li>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -80,20 +80,8 @@ img {
   margin: 0 auto;
   padding: 1rem 1.5rem;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
-}
-
-.nav-logo {
-  font-weight: 700;
-  font-size: 1.1rem;
-  color: var(--text-primary);
-  letter-spacing: -0.02em;
-}
-
-.nav-logo:hover {
-  color: var(--accent);
-  opacity: 1;
 }
 
 .nav-links {


### PR DESCRIPTION
The author name is redundant with the hero section and there's already a Home link, so removing it declutters the nav bar.

https://claude.ai/code/session_01YJfHWp7QGq4FcusiuGEWPD